### PR TITLE
473 - Notifications don't open the wallet app

### DIFF
--- a/lib/pushnotificationsservice.js
+++ b/lib/pushnotificationsservice.js
@@ -140,7 +140,6 @@ PushNotificationsService.prototype._sendPushNotifications = function(notificatio
                     title: content.plain.subject,
                     body: content.plain.body,
                     sound: "default",
-                    click_action: "FCM_PLUGIN_ACTIVITY",
                     icon: "fcm_push_icon",
                   },
                   data: {


### PR DESCRIPTION
FYI, the way that click_action is handled on Android, it should use reverse domain notation. In our case, it is completely unnecessary anyway.